### PR TITLE
Ditch the wandEnabled option in the config

### DIFF
--- a/src/nl/Steffion/BlockHunt/BlockHunt.java
+++ b/src/nl/Steffion/BlockHunt/BlockHunt.java
@@ -192,12 +192,11 @@ public class BlockHunt extends JavaPlugin implements Listener {
 				(Boolean) W.config.get(ConfigC.commandEnabled_start),
 				BlockHuntCMD, new CMDstart(),
 				"/BlockHunt <start|go> <arenaname>");
-		if (W.config.getFile().getBoolean("wandEnabled")) {
-			CMDwand = new CommandM("BlockHunt WAND", "BlockHunt", "wand", "w",
-					Permissions.create, ConfigC.help_wand,
-					(Boolean) W.config.get(ConfigC.commandEnabled_wand),
-					BlockHuntCMD, new CMDwand(), "/BlockHunt <wand|w>");
-		}
+		CMDwand = new CommandM("BlockHunt WAND", "BlockHunt", "wand",
+				"w", Permissions.create, ConfigC.help_wand,
+				(Boolean) W.config.get(ConfigC.commandEnabled_wand),
+				BlockHuntCMD, new CMDwand(),
+				"/BlockHunt <wand|w>");
 		CMDcreate = new CommandM("BlockHunt CREATE", "BlockHunt", "create",
 				"c", Permissions.create, ConfigC.help_create,
 				(Boolean) W.config.get(ConfigC.commandEnabled_create),


### PR DESCRIPTION
The option 'wandEnabled' has been removed from the default config, adding it does not enable the command, and it's the only command that still has that check (which is already performed by W.config.get(ConfigC.commandEnabled_wand)). Removing the if clause.